### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2023 The cdevents Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Just fixed a typo error in licensing
Adds the name of copyright owner in LICENSE file

Fixes #26

## Changes

```diff
-Copyright [yyyy] [name of copyright owner]
+Copyright 2023 The cdevents Authors
```
- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
